### PR TITLE
Stops the background icon image repeating.

### DIFF
--- a/admin/plugins/civicrmicon/civicrmicon.php
+++ b/admin/plugins/civicrmicon/civicrmicon.php
@@ -62,6 +62,7 @@ class plgQuickiconCivicrmicon extends JPlugin {
         .icon-civicrm, .icon-civicrm-open {
           {$additonalAttributes}
           background-image:url(\"{$img}\");
+          background-repeat: no-repeat;
         }
       ";
       $document = JFactory::getDocument();


### PR DESCRIPTION
a couple of pixels of the repeat were visible at my viewport (which might vary as quickicon uses rem for measurement).

## Before

![image](https://user-images.githubusercontent.com/1175967/170058057-7d5d8194-26eb-4568-8bda-a4f61b2d11bf.png)

## After

![image](https://user-images.githubusercontent.com/1175967/170058139-4e50c8dd-26ba-4b39-ad17-ad3a6346b462.png)

